### PR TITLE
Thumbnails + current wallpaper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /bin
 /obj
+/.vs/WindowsLockScreenImages
+/WindowsLockScreenImages.csproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
 /obj
-/.vs/WindowsLockScreenImages
+/.vs
+/Properties
 /WindowsLockScreenImages.csproj.user

--- a/WindowsLockScreenImages.csproj.user
+++ b/WindowsLockScreenImages.csproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup />
-</Project>

--- a/WindowsLockScreenImagesForm.cs
+++ b/WindowsLockScreenImagesForm.cs
@@ -8,26 +8,63 @@ public partial class WindowsLockScreenImagesForm : Form
     private FileInfo[] assets = Array.Empty<FileInfo>();
 
     private string assetsUserDirectory = string.Empty;
+    private string assetsLockScreenDirectory = string.Empty;
 
     private FileInfo[] getAssets()
     {
         var userDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        //const string directory = @"C:\Users\USERNAME\AppData\Local\Packages\Microsoft.Windows.ContentDeliveryManager_cw5n1h2txyewy\LocalState\Assets";
-        var directory = Path.Combine(userDirectory, @"AppData\Local\Packages\Microsoft.Windows.ContentDeliveryManager_cw5n1h2txyewy\LocalState\Assets");
-        this.assetsUserDirectory = directory;
-        if (!Directory.Exists(directory))
+        var wallpaper_directory = Path.Combine(userDirectory, @"AppData\Local\Packages\Microsoft.Windows.ContentDeliveryManager_cw5n1h2txyewy\LocalState\Assets");
+        var lockscreen_directory = Path.Combine(userDirectory, @"AppData\Roaming\Microsoft\Windows\Themes");
+        this.assetsUserDirectory = wallpaper_directory;
+        this.assetsLockScreenDirectory = lockscreen_directory;
+        if (!Directory.Exists(wallpaper_directory))
         {
-            MessageBox.Show($"Directory '{directory}' does not exist!", "Something went wrong", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBox.Show($"Directory '{wallpaper_directory}' does not exist!", "Something went wrong", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return this.assets;
         }
-        return new DirectoryInfo(directory).GetFiles();
+        if (!Directory.Exists(lockscreen_directory))
+        {
+            MessageBox.Show($"Directory '{lockscreen_directory}' does not exist!", "Something went wrong", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return this.assets;
+        }
+        List<FileInfo> files = new List<FileInfo>();
+        foreach (var file in new DirectoryInfo(wallpaper_directory).GetFiles())
+        {
+            if (file.Length >= 50 * 1024) // discard files < 50kb
+                files.Add(file);
+        }
+        foreach (var file in new DirectoryInfo(lockscreen_directory).GetFiles())
+        {
+            if (file.Extension != ".ini") // discard *.ini files
+                files.Add(file);
+        }
+        return files.ToArray();
+    }
+    private Bitmap CreateThumbnail(Image original, Size maxSize)
+    {
+        double ratioX = (double)maxSize.Width / original.Width;
+        double ratioY = (double)maxSize.Height / original.Height;
+        double ratio = Math.Min(ratioX, ratioY);
+
+        int newWidth = (int)(original.Width * ratio);
+        int newHeight = (int)(original.Height * ratio);
+
+        var thumb = new Bitmap(newWidth, newHeight);
+        using (var graphics = Graphics.FromImage(thumb))
+        {
+            graphics.CompositingQuality = System.Drawing.Drawing2D.CompositingQuality.HighQuality;
+            graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+            graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
+            graphics.DrawImage(original, 0, 0, newWidth, newHeight);
+        }
+        return thumb;
     }
 
     public WindowsLockScreenImagesForm()
     {
         InitializeComponent();
 
-        this.Icon = new Icon(AppDomain.CurrentDomain.BaseDirectory +  @"\WindowsLockScreenImagesIcon.ico");
+        this.Icon = new Icon(AppDomain.CurrentDomain.BaseDirectory + @"\WindowsLockScreenImagesIcon.ico");
 
         this.assets = getAssets();
 
@@ -44,7 +81,7 @@ public partial class WindowsLockScreenImagesForm : Form
         statusStrip.Items.Add(statusStripLabel);
         // buttons to save the selected file and to open the directory with explorer
         statusStrip.Items.Add(new ToolStripStatusLabel("") { Spring = true, TextAlign = ContentAlignment.MiddleRight });
-       var statusStripSaveButton = new ToolStripSplitButton("Click to save selected image")
+        var statusStripSaveButton = new ToolStripSplitButton("Click to save selected image")
         {
             DropDownButtonWidth = 0
         };
@@ -73,10 +110,6 @@ public partial class WindowsLockScreenImagesForm : Form
                     }
                 }
             }
-            else
-            {
-                MessageBox.Show("Click on an image on the list to select it and save it.", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            }
         };
         statusStrip.Items.Add(statusStripSaveButton);
         statusStrip.Items.Add(new ToolStripSeparator());
@@ -84,14 +117,22 @@ public partial class WindowsLockScreenImagesForm : Form
         {
             DropDownButtonWidth = 0
         };
+        // open explorer on the two directories
         statusStripOpenButton.Click += (s, e) =>
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo
+            ProcessStartInfo startInfo1 = new ProcessStartInfo
             {
                 Arguments = this.assetsUserDirectory,
                 FileName = "explorer.exe"
             };
-            Process.Start(startInfo);
+
+            ProcessStartInfo startInfo2 = new ProcessStartInfo
+            {
+                Arguments = this.assetsLockScreenDirectory,
+                FileName = "explorer.exe"
+            };
+            Process.Start(startInfo1);
+            Process.Start(startInfo2);
         };
         statusStrip.Items.Add(statusStripOpenButton);
         // split panel
@@ -104,39 +145,92 @@ public partial class WindowsLockScreenImagesForm : Form
         var pictureBox = new PictureBox
         {
             Dock = DockStyle.Fill,
-            SizeMode = PictureBoxSizeMode.Zoom
+            SizeMode = PictureBoxSizeMode.Zoom,
         };
-        // left = list of files
-        listBox = new ListBox
+        var pictureContainer = new Panel
         {
-            Dock = DockStyle.Fill
+            Dock = DockStyle.Fill,
+            Padding = new Padding(20),
+            BackColor = SystemColors.ControlDarkDark
         };
+        pictureContainer.Controls.Add(pictureBox);
+        // create thumbnail viewer
+        var thumbnailPanel = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoScroll = true,
+            WrapContents = true,
+            FlowDirection = FlowDirection.LeftToRight
+        };
+
+        // map thumbnail PictureBox to FileInfo
+        Dictionary<PictureBox, FileInfo> pictureMap = new();
+
+        PictureBox? selectedThumbnail = null;
+
         foreach (var fileInfo in this.assets)
         {
-            listBox.Items.Add(new ListBoxMetaItem(fileInfo));
-        }
-        listBox.Click += (s, e) =>
-        {
-            var selectedIndex = listBox.SelectedIndex;
-            if (selectedIndex >= 0)
+            try
             {
-                var metaItem = listBox.Items[selectedIndex] as ListBoxMetaItem;
-                if (metaItem is not null)
+                using var tempImage = Image.FromFile(fileInfo.FullName);
+                var thumbnail = CreateThumbnail(tempImage, new Size(100, 60));
+
+                var picBox = new PictureBox
                 {
-                    var fullFileName = metaItem.Info?.FullName;
-                    if (File.Exists(fullFileName))
+                    Image = thumbnail,
+                    Width = 100,
+                    Height = 60,
+                    SizeMode = PictureBoxSizeMode.Zoom,
+                    Cursor = Cursors.Hand,
+                    Margin = new Padding(5)
+                };
+
+                picBox.Click += (s, e) =>
+                {
+                    if (File.Exists(fileInfo.FullName))
                     {
-                        pictureBox.Image = Image.FromFile(fullFileName);
+                        pictureBox.Image = Image.FromFile(fileInfo.FullName);
+
+                        var filenameLength = fileInfo.Name.Length;
+                        statusStripLabel.Text = $"{fileInfo.Name.Substring(0, 4)}...{fileInfo.Name.Substring(filenameLength - 4, 4)} ({new ListBoxMetaItem(fileInfo).HumanReadableSize()})";
+
+                        selectedThumbnail = (PictureBox)s!;
                     }
-                    var item = (ToolStripStatusLabel)statusStrip.Items[0];
-                    var filenameLength = (metaItem.Info is not null) ? metaItem.Info.Name.Length : 0;
-                    item.Text = $"{metaItem.Info?.Name.Substring(0, 4)}...{metaItem.Info?.Name.Substring(filenameLength - 4, 4)} ({metaItem.HumanReadableSize()})";
+                };
+
+                pictureMap[picBox] = fileInfo;
+                thumbnailPanel.Controls.Add(picBox);
+            }
+            catch
+            {
+                // discard invalid image files
+            }
+        }
+
+        statusStripSaveButton.Click += (s, e) =>
+        {
+            if (selectedThumbnail != null && pictureMap.TryGetValue(selectedThumbnail, out var selectedFile))
+            {
+                var saveFileDialog = new SaveFileDialog
+                {
+                    FileName = $"{selectedFile.Name}.jpg",
+                    Filter = "JPEG (*.jpg)|*.jpeg,*.jpg",
+                    InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop)
+                };
+
+                if (saveFileDialog.ShowDialog() == DialogResult.OK)
+                {
+                    Image.FromFile(selectedFile.FullName).Save(saveFileDialog.FileName, ImageFormat.Jpeg);
                 }
+            }
+            else
+            {
+                MessageBox.Show("Click on an image to select it and save it.", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         };
         //
-        splitContainer.Panel1.Controls.Add(listBox);
-        splitContainer.Panel2.Controls.Add(pictureBox);
+        splitContainer.Panel1.Controls.Add(thumbnailPanel);
+        splitContainer.Panel2.Controls.Add(pictureContainer);
         //
         this.Controls.Add(splitContainer);
         this.Controls.Add(statusStrip);

--- a/WindowsLockScreenImagesForm.cs
+++ b/WindowsLockScreenImagesForm.cs
@@ -9,14 +9,17 @@ public partial class WindowsLockScreenImagesForm : Form
 
     private string assetsUserDirectory = string.Empty;
     private string assetsLockScreenDirectory = string.Empty;
+    private string assetsWallpaperIris = string.Empty;
 
     private FileInfo[] getAssets()
     {
         var userDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var wallpaper_directory = Path.Combine(userDirectory, @"AppData\Local\Packages\Microsoft.Windows.ContentDeliveryManager_cw5n1h2txyewy\LocalState\Assets");
         var lockscreen_directory = Path.Combine(userDirectory, @"AppData\Roaming\Microsoft\Windows\Themes");
+        var wallpaper_iris = Path.Combine(userDirectory, @"AppData\Local\Packages\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\LocalCache\Microsoft\IrisService");
         this.assetsUserDirectory = wallpaper_directory;
         this.assetsLockScreenDirectory = lockscreen_directory;
+        this.assetsWallpaperIris = wallpaper_iris;
         if (!Directory.Exists(wallpaper_directory))
         {
             MessageBox.Show($"Directory '{wallpaper_directory}' does not exist!", "Something went wrong", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -27,6 +30,11 @@ public partial class WindowsLockScreenImagesForm : Form
             MessageBox.Show($"Directory '{lockscreen_directory}' does not exist!", "Something went wrong", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return this.assets;
         }
+        if (!Directory.Exists(wallpaper_iris))
+        {
+            MessageBox.Show($"Directory '{wallpaper_iris}' does not exist!", "Something went wrong", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return this.assets;
+        }
         List<FileInfo> files = new List<FileInfo>();
         foreach (var file in new DirectoryInfo(wallpaper_directory).GetFiles())
         {
@@ -34,6 +42,11 @@ public partial class WindowsLockScreenImagesForm : Form
                 files.Add(file);
         }
         foreach (var file in new DirectoryInfo(lockscreen_directory).GetFiles())
+        {
+            if (file.Extension != ".ini") // discard *.ini files
+                files.Add(file);
+        }
+        foreach (var file in new DirectoryInfo(wallpaper_iris).GetFiles("*", SearchOption.AllDirectories))
         {
             if (file.Extension != ".ini") // discard *.ini files
                 files.Add(file);
@@ -81,10 +94,7 @@ public partial class WindowsLockScreenImagesForm : Form
         statusStrip.Items.Add(statusStripLabel);
         // buttons to save the selected file and to open the directory with explorer
         statusStrip.Items.Add(new ToolStripStatusLabel("") { Spring = true, TextAlign = ContentAlignment.MiddleRight });
-        var statusStripSaveButton = new ToolStripSplitButton("Click to save selected image")
-        {
-            DropDownButtonWidth = 0
-        };
+        var statusStripSaveButton = new ToolStripSplitButton("Click to save selected image");
         statusStripSaveButton.Click += (s, e) =>
         {
             var selectedIndex = listBox.SelectedIndex;
@@ -113,10 +123,7 @@ public partial class WindowsLockScreenImagesForm : Form
         };
         statusStrip.Items.Add(statusStripSaveButton);
         statusStrip.Items.Add(new ToolStripSeparator());
-        var statusStripOpenButton = new ToolStripSplitButton("Click to open images folder")
-        {
-            DropDownButtonWidth = 0
-        };
+        var statusStripOpenButton = new ToolStripSplitButton("Click to open images folder");
         // open explorer on the two directories
         statusStripOpenButton.Click += (s, e) =>
         {
@@ -131,8 +138,16 @@ public partial class WindowsLockScreenImagesForm : Form
                 Arguments = this.assetsLockScreenDirectory,
                 FileName = "explorer.exe"
             };
+
+            ProcessStartInfo startInfo3 = new ProcessStartInfo
+            {
+                Arguments = this.assetsWallpaperIris,
+                FileName = "explorer.exe"
+            };
+
             Process.Start(startInfo1);
             Process.Start(startInfo2);
+            Process.Start(startInfo3);
         };
         statusStrip.Items.Add(statusStripOpenButton);
         // split panel


### PR DESCRIPTION
I added the current wallpaper (the file TranscodedWallpaper in C:\Users\<user>\AppData\Roaming\Microsoft\Windows\Themes) to the file list because it most often is different from the lockscreen pictures. I also made a panel that list all the pictures in a thumbnail for a quick overview of which image to select.

Detailed list of changes:
- add current wallpaper directory to files array and filter out *.ini file
- skip files < 50kb for lockscreen pictures (hides the xbox thing)
- open second explorer instance on current wallpaper directory
- create a FlowLayoutPanel containing thumbnails of all pictures in their respective orientation to visually see portrait vs landscape
- add some padding and a background color to the selected pictures via a container